### PR TITLE
fix RatingBar with RTL support

### DIFF
--- a/designsystem/safeimageviewer/src/main/java/com/designSystem/safeimageviewer/SafeImageViewer.kt
+++ b/designsystem/safeimageviewer/src/main/java/com/designSystem/safeimageviewer/SafeImageViewer.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.createBitmap
 import coil.compose.AsyncImage
@@ -40,11 +41,13 @@ fun SafeImageViewer(
     confidenceThreshold: Float = 0.7f,
     showLoadingIndicator: Boolean = true,
     placeholder: @Composable (() -> Unit)? = null,
+    errorPlaceholder: @Composable (() -> Unit)? = null
 ) {
     val context = LocalContext.current
     var isNSFW by remember { mutableStateOf(false) }
     var drawable by remember { mutableStateOf<Drawable?>(null) }
     var isLoading by remember { mutableStateOf(true) }
+    var isError by remember { mutableStateOf(false) }
     var isAnalyzing by remember { mutableStateOf(false) }
     val nsfwDetector = remember { NSFWDetector(context) }
 
@@ -108,21 +111,25 @@ fun SafeImageViewer(
                 when (state) {
                     is AsyncImagePainter.State.Loading -> {
                         isLoading = true
+                        isError = false
                         isAnalyzing = false
                     }
 
                     is AsyncImagePainter.State.Success -> {
                         isLoading = false
+                        isError = false
                         drawable = state.result.drawable
                     }
 
                     is AsyncImagePainter.State.Error -> {
                         isLoading = false
+                        isError = true
                         isAnalyzing = false
                     }
 
                     else -> {
                         isLoading = false
+                        isError = false
                         isAnalyzing = false
                     }
                 }
@@ -135,6 +142,14 @@ fun SafeImageViewer(
                 contentAlignment = Alignment.Center
             ) {
                 placeholder?.invoke() ?: CircularProgressIndicator()
+            }
+        }
+        if (isError) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                errorPlaceholder?.invoke() ?: CircularProgressIndicator()
             }
         }
     }

--- a/designsystem/src/main/java/com/paris_2/aflami/designsystem/components/AflamiMediaCard.kt
+++ b/designsystem/src/main/java/com/paris_2/aflami/designsystem/components/AflamiMediaCard.kt
@@ -91,6 +91,14 @@ fun AflamiMediaCard(
                     modifier = Modifier.size(48.dp),
                     contentScale = ContentScale.Crop
                 )
+            },
+            errorPlaceholder = {
+                Image(
+                    painter = painterResource(id = R.drawable.img_disconnect),
+                    contentDescription = null,
+                    modifier = Modifier.size(48.dp),
+                    contentScale = ContentScale.Crop
+                )
             }
         )
 

--- a/designsystem/src/main/java/com/paris_2/aflami/designsystem/components/RatingBar.kt
+++ b/designsystem/src/main/java/com/paris_2/aflami/designsystem/components/RatingBar.kt
@@ -1,5 +1,7 @@
 package com.paris_2.aflami.designsystem.components
 
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -8,8 +10,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.gestures.detectHorizontalDragGestures
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -26,9 +26,11 @@ import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.paris_2.aflami.designsystem.R
 import com.paris_2.aflami.designsystem.theme.Theme
@@ -44,6 +46,7 @@ fun RatingBar(
     onRatingChange: (Float) -> Unit
 ) {
     val density = LocalDensity.current
+    val layoutDirection = LocalLayoutDirection.current
 
     Row(
         modifier = modifier
@@ -51,12 +54,13 @@ fun RatingBar(
             .pointerInput(maxRating, starSize, spaceBetween) {
                 detectHorizontalDragGestures { change, _ ->
                     val x = change.position.x
-                    // Calculate the star index based on x position
                     val starWidthPx = with(density) { starSize.toPx() }
                     val spaceBetweenPx = with(density) { spaceBetween.toPx() }
                     val totalStarWidth = starWidthPx + spaceBetweenPx
-
-                    val calculatedRating = (x / totalStarWidth).coerceIn(0f, maxRating.toFloat())
+                    val effectiveX =
+                        if (layoutDirection == LayoutDirection.Rtl) size.width - x else x
+                    val calculatedRating =
+                        (effectiveX / totalStarWidth).coerceIn(0f, maxRating.toFloat())
                     onRatingChange(calculatedRating)
                 }
             }
@@ -65,7 +69,8 @@ fun RatingBar(
                     val starWidthPx = with(density) { starSize.toPx() }
                     val spaceBetweenPx = with(density) { spaceBetween.toPx() }
                     val totalStarWidth = starWidthPx + spaceBetweenPx
-                    val x = offset.x
+                    val x =
+                        if (layoutDirection == LayoutDirection.Rtl) size.width - offset.x else offset.x
                     val calculatedRating = (x / totalStarWidth).coerceIn(0f, maxRating.toFloat())
                     onRatingChange(calculatedRating)
                 }
@@ -82,6 +87,7 @@ fun RatingBar(
             StarIconFromResource(
                 modifier = Modifier.size(starSize),
                 fillRatio = fillRatio,
+                layoutDirection = layoutDirection,
                 selectedColor = selectedColor
             )
         }
@@ -92,6 +98,7 @@ fun RatingBar(
 private fun StarIconFromResource(
     modifier: Modifier = Modifier,
     fillRatio: Float,
+    layoutDirection: LayoutDirection,
     selectedColor: Color = Theme.colors.status.yellowAccent
 ) {
     Box(
@@ -116,7 +123,9 @@ private fun StarIconFromResource(
                     compositingStrategy = CompositingStrategy.Offscreen
                 }
                 .drawWithContent {
-                    clipRect(right = size.width * fillRatio) {
+                    clipRect(
+                        right = if (layoutDirection == LayoutDirection.Rtl) size.width else size.width * fillRatio,
+                        left = if (layoutDirection == LayoutDirection.Rtl) size.width - size.width * fillRatio else 0f) {
                         this@drawWithContent.drawContent()
                     }
                 }

--- a/designsystem/src/main/java/com/paris_2/aflami/designsystem/components/TextFields.kt
+++ b/designsystem/src/main/java/com/paris_2/aflami/designsystem/components/TextFields.kt
@@ -232,9 +232,11 @@ fun TextField(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .clip(shape)
                     .background(Theme.colors.surfaceHigh)
                     .border(BorderStroke(1.dp, Theme.colors.stroke), shape)
-                    .heightIn(max = 200.dp)
+                    .heightIn(max = 300.dp)
                     .verticalScroll(rememberScrollState())
             ) {
                 filteredSuggestions.forEach { suggestion ->


### PR DESCRIPTION
This commit introduces Right-to-Left (RTL) language support for the `RatingBar` composable.

Key changes:
- The `RatingBar` now considers `LocalLayoutDirection` to correctly calculate rating based on touch and drag gestures in both LTR and RTL layouts.
- `StarIconFromResource` now also uses `LocalLayoutDirection` to adjust the clipping mask for partial star fills in RTL.