### PR TITLE
Fix: Update APK path in Firebase App Distribution workflow

### DIFF
--- a/.github/workflows/cd-firebase-app-distribution.yml
+++ b/.github/workflows/cd-firebase-app-distribution.yml
@@ -33,6 +33,6 @@ jobs:
           appId: ${{ secrets.FIREBASE_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
           groups: testers
-          file: app/build/outputs/apk/debug/app-debug.apk
+          file: feature/search/searchUi/build/outputs/apk/debug/searchUi-debug.apk
           releaseNotes: "Automated release from develop branch"
           debug: true


### PR DESCRIPTION
The path to the APK file in the `cd-firebase-app-distribution.yml` GitHub Actions workflow has been corrected.

The previous path was `app/build/outputs/apk/debug/app-debug.apk`. The updated path is `feature/search/searchUi/build/outputs/apk/debug/searchUi-debug.apk`.