### PR TITLE
feature/add-app-icon

### DIFF
--- a/app/release-info.txt
+++ b/app/release-info.txt
@@ -1,2 +1,2 @@
-versionName=0.8.1
-- replace web view with media player
+versionName=0.8.2
+- add app icon in dark and light theme

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,9 +10,9 @@
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
-        android:icon="@drawable/ic_aflami_logo"
+        android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:roundIcon="@drawable/ic_aflami_logo"
+        android:roundIcon="@mipmap/ic_launcher"
         android:supportsRtl="true"
         android:theme="@style/Theme.Aflami"
         tools:targetApi="35">

--- a/app/src/main/res/drawable/ic_aflami_launcher_inset.xml
+++ b/app/src/main/res/drawable/ic_aflami_launcher_inset.xml
@@ -1,0 +1,3 @@
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:drawable="@drawable/ic_aflami_logo"
+    android:inset="24dp" />

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@drawable/ic_launcher_background" />
-    <foreground android:drawable="@drawable/ic_launcher_foreground" />
-    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+    <background android:drawable="@color/ic_background_color" />
+    <foreground android:drawable="@drawable/ic_aflami_launcher_inset" />
+    <monochrome android:drawable="@drawable/ic_aflami_launcher_inset"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@drawable/ic_launcher_background" />
-    <foreground android:drawable="@drawable/ic_launcher_foreground" />
-    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+    <background android:drawable="@color/ic_background_color" />
+    <foreground android:drawable="@drawable/ic_aflami_launcher_inset" />
+    <monochrome android:drawable="@drawable/ic_aflami_launcher_inset"/>
 </adaptive-icon>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="surface">#0D090B</color>
+    <color name="ic_background_color">@color/black</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,4 +8,5 @@
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
     <color name="surface">#FAF5F7</color>
+    <color name="ic_background_color">@color/white</color>
 </resources>

--- a/feature/bottomNavBar/bottomNavBarUI/src/main/AndroidManifest.xml
+++ b/feature/bottomNavBar/bottomNavBarUI/src/main/AndroidManifest.xml
@@ -7,7 +7,6 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
     </application>


### PR DESCRIPTION
- add app icon in dark and light theme 
- fix the issue of 2 icons that created by launcher 
<img width="360" height="360" alt="ic_dark" src="https://github.com/user-attachments/assets/dd90b357-5baa-4d21-b43f-bfc2aabc64e0" />
<img width="360" height="360" alt="ic_light" src="https://github.com/user-attachments/assets/123bd815-86f8-495d-84ff-2dcf46120a8c" />
