### PR TITLE
Rename classes and update imports for consistency

### DIFF
--- a/app/release-info.txt
+++ b/app/release-info.txt
@@ -1,2 +1,2 @@
-versionName=0.8.4
-- refactor gradle
+versionName=0.8.5
+- rename classes from imp to impl

--- a/app/src/main/java/com/paris_2/aflami/di/DataSourceModule.kt
+++ b/app/src/main/java/com/paris_2/aflami/di/DataSourceModule.kt
@@ -8,8 +8,8 @@ import androidx.datastore.preferences.preferencesDataStoreFile
 import androidx.work.WorkManager
 import com.datasource.local.dao.MovieDao
 import com.datasource.local.dao.TvShowDao
-import com.datasource.local.datasource.MovieLocalDataSourceImp
-import com.datasource.local.datasource.TvShowLocalDataSourceImp
+import com.datasource.local.datasource.MovieLocalDataSourceImpl
+import com.datasource.local.datasource.TvShowLocalDataSourceImpl
 import com.datasource.local.media.dao.ContinueWatchingDao
 import com.datasource.local.media.dao.CountryDao
 import com.datasource.local.media.dao.GenresUserInteractionDao
@@ -20,10 +20,10 @@ import com.datasource.local.media.datasource.CountriesLocalDataSourceImpl
 import com.datasource.local.media.datasource.GenresInteractionDataSourceImpl
 import com.datasource.local.media.datasource.HistoryLocalDataSourceImpl
 import com.datasource.local.media.datasource.HomeMediaLocalDataSourceImpl
-import com.datasource.remote.lists.ListsRemoteDataSourceImp
+import com.datasource.remote.lists.ListsRemoteDataSourceImpl
 import com.datasource.remote.lists.service.ListApiService
 import com.paris_2.dataSource.local.user.AuthenticationLocalDataSourceImpl
-import com.paris_2.dataSource.local.user.SettingLocalDataSourceImp
+import com.paris_2.dataSource.local.user.SettingLocalDataSourceImpl
 import com.paris_2.datasource.remote.user.UserApi
 import com.paris_2.datasource.remote.user.UserRemoteDataSourceImpl
 import com.paris_2.repository.user.dataSource.local.AuthenticationLocalDataSource
@@ -80,14 +80,14 @@ object DataSourceModule {
     fun provideMovieLocalDataSource(
         workManager: WorkManager,
         movieDao: MovieDao,
-    ): MovieLocalDataSource = MovieLocalDataSourceImp(workManager, movieDao)
+    ): MovieLocalDataSource = MovieLocalDataSourceImpl(workManager, movieDao)
 
     @Provides
     @Singleton
     fun provideTvShowLocalDataSource(
         workManager: WorkManager,
         dao: TvShowDao,
-    ): TvShowLocalDataSource = TvShowLocalDataSourceImp(workManager, dao)
+    ): TvShowLocalDataSource = TvShowLocalDataSourceImpl(workManager, dao)
 
     @Provides
     @Singleton
@@ -118,14 +118,14 @@ object DataSourceModule {
     @Singleton
     fun provideLanguageLocalDataSource(
        @ApplicationContext context: Context,
-    ): SettingLocalDataSource = SettingLocalDataSourceImp(context)
+    ): SettingLocalDataSource = SettingLocalDataSourceImpl(context)
 
     @Provides
     @Singleton
     fun provideListRemoteDataSource(
         listApiService: ListApiService
     ): ListsRemoteDataSource {
-        return ListsRemoteDataSourceImp(listApiService)
+        return ListsRemoteDataSourceImpl(listApiService)
     }
 
 }

--- a/app/src/main/java/com/paris_2/aflami/di/RepositoryModule.kt
+++ b/app/src/main/java/com/paris_2/aflami/di/RepositoryModule.kt
@@ -15,11 +15,11 @@ import com.paris_2.domain.user.repository.UserRepository
 import com.paris_2.repository.user.dataSource.local.AuthenticationLocalDataSource
 import com.paris_2.repository.user.dataSource.local.SettingLocalDataSource
 import com.paris_2.repository.user.dataSource.remote.UserRemoteDataSource
-import com.paris_2.repository.user.repository.SettingRepositoryImp
+import com.paris_2.repository.user.repository.SettingRepositoryImpl
 import com.paris_2.repository.user.repository.UserRepositoryImpl
 import com.repository.dataSource.local.TvShowLocalDataSource
 import com.repository.dataSource.remote.TvShowDetailsRemoteDataSource
-import com.repository.lists.ListsRepositoryImp
+import com.repository.lists.ListsRepositoryImpl
 import com.repository.lists.dataSource.remote.ListsRemoteDataSource
 import com.repository.media.datasource.local.ContinueWatchingLocalDataSource
 import com.repository.media.datasource.local.CountriesLocalDataSource
@@ -117,7 +117,7 @@ object RepositoryModule {
     @Singleton
     fun provideLanguageRepository(
         settingLocalDataSource: SettingLocalDataSource,
-    ): SettingRepository = SettingRepositoryImp(settingLocalDataSource)
+    ): SettingRepository = SettingRepositoryImpl(settingLocalDataSource)
 
     @Provides
     @Singleton
@@ -180,5 +180,5 @@ object RepositoryModule {
     fun provideListsTvShowRepository(
         listRemoteDataSource: ListsRemoteDataSource,
         userRemoteDataSource: UserRemoteDataSource
-    ): ListsRepository = ListsRepositoryImp(listRemoteDataSource, userRemoteDataSource)
+    ): ListsRepository = ListsRepositoryImpl(listRemoteDataSource, userRemoteDataSource)
 }

--- a/datasource/local/movie/src/main/java/com/datasource/local/datasource/MovieLocalDataSourceImpl.kt
+++ b/datasource/local/movie/src/main/java/com/datasource/local/datasource/MovieLocalDataSourceImpl.kt
@@ -13,7 +13,7 @@ import com.repository.movie.models.local.MovieSimilarEntity
 import com.repository.movie.models.local.ReviewEntity
 import java.util.concurrent.TimeUnit
 
-class MovieLocalDataSourceImp(
+class MovieLocalDataSourceImpl(
     private val workManager: WorkManager,
     private val movieDao: MovieDao
 ) : MovieLocalDataSource {

--- a/datasource/local/movie/src/test/java/com/datasource/local/datasource/MovieLocalDataSourceImpTest.kt
+++ b/datasource/local/movie/src/test/java/com/datasource/local/datasource/MovieLocalDataSourceImpTest.kt
@@ -24,14 +24,14 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class MovieLocalDataSourceImpTest {
-    private lateinit var movieLocalDataSource: MovieLocalDataSourceImp
+    private lateinit var movieLocalDataSource: MovieLocalDataSourceImpl
     private var workManager: WorkManager = mockk(relaxed = true)
     private lateinit var movieDao: MovieDao
 
     @BeforeEach
     fun setUp() {
         movieDao = mockk(relaxed = true)
-        movieLocalDataSource = MovieLocalDataSourceImp(workManager, movieDao)
+        movieLocalDataSource = MovieLocalDataSourceImpl(workManager, movieDao)
     }
 
     @Nested

--- a/datasource/local/tvShow/src/main/java/com/datasource/local/datasource/TvShowLocalDataSourceImpl.kt
+++ b/datasource/local/tvShow/src/main/java/com/datasource/local/datasource/TvShowLocalDataSourceImpl.kt
@@ -14,7 +14,7 @@ import com.repository.model.local.TvShowEntity
 import com.repository.model.local.TvShowSimilarEntity
 import java.util.concurrent.TimeUnit
 
-class TvShowLocalDataSourceImp (
+class TvShowLocalDataSourceImpl (
     private val workManager: WorkManager,
     private val tvShowDao: TvShowDao
 ) : TvShowLocalDataSource {

--- a/datasource/local/tvShow/src/test/java/com/datasource/local/datasource/TvShowLocalDataSourceImplTest.kt
+++ b/datasource/local/tvShow/src/test/java/com/datasource/local/datasource/TvShowLocalDataSourceImplTest.kt
@@ -26,15 +26,15 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import kotlin.test.Test
 
-class TvShowLocalDataSourceImpTest {
-    private lateinit var tvShowLocalDataSourceImp: TvShowLocalDataSourceImp
+class TvShowLocalDataSourceImplTest {
+    private lateinit var tvShowLocalDataSourceImpl: TvShowLocalDataSourceImpl
     private var workManager: WorkManager = mockk(relaxed = true)
     private lateinit var tvShowDao: TvShowDao
 
     @BeforeEach
     fun setUp() {
         tvShowDao = mockk(relaxed = true)
-        tvShowLocalDataSourceImp = TvShowLocalDataSourceImp(workManager, tvShowDao)
+        tvShowLocalDataSourceImpl = TvShowLocalDataSourceImpl(workManager, tvShowDao)
 
     }
 
@@ -43,7 +43,7 @@ class TvShowLocalDataSourceImpTest {
         @Test
         fun `addTvShow should add tv show when addTvShow in TvShowDao is called`() = runTest {
             //Given
-            tvShowLocalDataSourceImp.addTvShow(sampleTvShow)
+            tvShowLocalDataSourceImpl.addTvShow(sampleTvShow)
 
             //When&Then
             coVerify(exactly = 1) { tvShowDao.addTvShow(sampleTvShow) }
@@ -56,7 +56,7 @@ class TvShowLocalDataSourceImpTest {
             coEvery { tvShowDao.getTvShowById(tvShowId, language) } returns sampleTvShow
 
             //When
-            val result = tvShowLocalDataSourceImp.getTvShowId(tvShowId, language)
+            val result = tvShowLocalDataSourceImpl.getTvShowId(tvShowId, language)
 
             //Then
             assertEquals(sampleTvShow, result)
@@ -70,7 +70,7 @@ class TvShowLocalDataSourceImpTest {
                 coEvery { tvShowDao.getTvShowById(tvShowId, language) } returns sampleTvShow
 
                 //When
-                tvShowLocalDataSourceImp.getTvShowId(tvShowId, language)
+                tvShowLocalDataSourceImpl.getTvShowId(tvShowId, language)
 
                 //Then
                 coVerify(exactly = 1) { tvShowDao.getTvShowById(tvShowId, language) }
@@ -83,7 +83,7 @@ class TvShowLocalDataSourceImpTest {
             coEvery { tvShowDao.getTvShowById(tvShowId, language) } returns null
 
             //When
-            val result = tvShowLocalDataSourceImp.getTvShowId(tvShowId, language)
+            val result = tvShowLocalDataSourceImpl.getTvShowId(tvShowId, language)
 
             //Then
             assertNull(result)
@@ -98,7 +98,7 @@ class TvShowLocalDataSourceImpTest {
                 coEvery { tvShowDao.getTvShowById(tvShowId, language) } returns null
 
                 //When
-                tvShowLocalDataSourceImp.getTvShowId(tvShowId, language)
+                tvShowLocalDataSourceImpl.getTvShowId(tvShowId, language)
 
                 //Then
                 coVerify(exactly = 1) { tvShowDao.getTvShowById(tvShowId, language) }
@@ -110,7 +110,7 @@ class TvShowLocalDataSourceImpTest {
         @Test
         fun `addCast should add cast when addCast in CastDao called successfully`() = runTest {
             //Given
-            tvShowLocalDataSourceImp.addTvShowCast(
+            tvShowLocalDataSourceImpl.addTvShowCast(
                 listOf(
                     sampleCast,
                     sampleCast2
@@ -119,7 +119,7 @@ class TvShowLocalDataSourceImpTest {
 
             //When&Then
             coVerify(exactly = 1) {
-                tvShowLocalDataSourceImp.addTvShowCast(
+                tvShowLocalDataSourceImpl.addTvShowCast(
                     listOf(
                         sampleCast,
                         sampleCast2
@@ -143,7 +143,7 @@ class TvShowLocalDataSourceImpTest {
                 } returns sampleCastList
 
                 //When
-                val result = tvShowLocalDataSourceImp.getCastByTvShowId(
+                val result = tvShowLocalDataSourceImpl.getCastByTvShowId(
                     tvShowId,
                     language
                 )
@@ -166,7 +166,7 @@ class TvShowLocalDataSourceImpTest {
             } returns sampleCastList
 
             //When
-            tvShowLocalDataSourceImp.getCastByTvShowId(tvShowId, language)
+            tvShowLocalDataSourceImpl.getCastByTvShowId(tvShowId, language)
 
             //Then
             coVerify(exactly = 1) { tvShowDao.getCastByTvShowId(tvShowId, language) }
@@ -187,7 +187,7 @@ class TvShowLocalDataSourceImpTest {
             } returns emptyList
 
             //When
-            val result = tvShowLocalDataSourceImp.getCastByTvShowId(tvShowIdWithNoCast, language)
+            val result = tvShowLocalDataSourceImpl.getCastByTvShowId(tvShowIdWithNoCast, language)
 
             //Then
             assertEquals(emptyList, result)
@@ -207,7 +207,7 @@ class TvShowLocalDataSourceImpTest {
             } returns emptyList()
 
             //When
-            tvShowLocalDataSourceImp.getCastByTvShowId(tvShowIdWithNoCast, language)
+            tvShowLocalDataSourceImpl.getCastByTvShowId(tvShowIdWithNoCast, language)
 
             //Then
             coVerify(exactly = 1) { tvShowDao.getCastByTvShowId(tvShowIdWithNoCast, language) }
@@ -219,7 +219,7 @@ class TvShowLocalDataSourceImpTest {
         @Test
         fun `should add gallery when addGallery is called`() = runTest {
             // Given
-            tvShowLocalDataSourceImp.addTvShowGallery(sampleGallery)
+            tvShowLocalDataSourceImpl.addTvShowGallery(sampleGallery)
 
             // When&Then
             coVerify(exactly = 1) { tvShowDao.addTvShowGallery(sampleGallery) }
@@ -232,7 +232,7 @@ class TvShowLocalDataSourceImpTest {
             coEvery { tvShowDao.getGalleryByTvShowId(movieId) } returns sampleGallery
 
             //When
-            val result = tvShowLocalDataSourceImp.getGalleryByTvShowId(movieId)
+            val result = tvShowLocalDataSourceImpl.getGalleryByTvShowId(movieId)
 
             //Then
             assertThat(result).isEqualTo(sampleGallery)
@@ -245,7 +245,7 @@ class TvShowLocalDataSourceImpTest {
             coEvery { tvShowDao.getGalleryByTvShowId(movieId) } returns sampleGallery
 
             // WHEN
-            tvShowLocalDataSourceImp.getGalleryByTvShowId(movieId)
+            tvShowLocalDataSourceImpl.getGalleryByTvShowId(movieId)
 
             // THEN
             coVerify(exactly = 1) { tvShowDao.getGalleryByTvShowId(movieId) }
@@ -258,7 +258,7 @@ class TvShowLocalDataSourceImpTest {
             coEvery { tvShowDao.getGalleryByTvShowId(movieId) } returns null
 
             //When
-            val result = tvShowLocalDataSourceImp.getGalleryByTvShowId(movieId)
+            val result = tvShowLocalDataSourceImpl.getGalleryByTvShowId(movieId)
 
             //Then
             assertThat(result).isNull()
@@ -272,7 +272,7 @@ class TvShowLocalDataSourceImpTest {
                 coEvery { tvShowDao.getGalleryByTvShowId(movieId) } returns null
 
                 // WHEN
-                tvShowLocalDataSourceImp.getGalleryByTvShowId(movieId)
+                tvShowLocalDataSourceImpl.getGalleryByTvShowId(movieId)
 
                 // THEN
                 coVerify(exactly = 1) { tvShowDao.getGalleryByTvShowId(movieId) }
@@ -284,7 +284,7 @@ class TvShowLocalDataSourceImpTest {
         @Test
         fun `addReview should add review when addReview in ReviewDao is called`() = runTest {
             //Given
-            tvShowLocalDataSourceImp.addTvShowReviews(listOf(sampleReview))
+            tvShowLocalDataSourceImpl.addTvShowReviews(listOf(sampleReview))
 
             //When&Then
             coVerify(exactly = 1) { tvShowDao.addTvShowReviews(listOf(sampleReview)) }
@@ -299,7 +299,7 @@ class TvShowLocalDataSourceImpTest {
             )
 
             //When
-            val result = tvShowLocalDataSourceImp.getReviewsByTvShowId(
+            val result = tvShowLocalDataSourceImpl.getReviewsByTvShowId(
                 tvShowId,
                 language
             )
@@ -321,7 +321,7 @@ class TvShowLocalDataSourceImpTest {
             } returns listOf(sampleReview)
 
             // WHEN
-            tvShowLocalDataSourceImp.getReviewsByTvShowId(
+            tvShowLocalDataSourceImpl.getReviewsByTvShowId(
                 tvShowId,
                 language
             )
@@ -348,7 +348,7 @@ class TvShowLocalDataSourceImpTest {
                 } returns emptyList()
 
                 // WHEN
-                val result = tvShowLocalDataSourceImp.getReviewsByTvShowId(
+                val result = tvShowLocalDataSourceImpl.getReviewsByTvShowId(
                     tvShowId,
                     language
                 )
@@ -365,7 +365,7 @@ class TvShowLocalDataSourceImpTest {
                 coEvery { tvShowDao.getReviewsByTvShowId(tvShowId, language) } returns emptyList()
 
                 // WHEN
-                tvShowLocalDataSourceImp.getReviewsByTvShowId(tvShowId, language)
+                tvShowLocalDataSourceImpl.getReviewsByTvShowId(tvShowId, language)
 
                 // THEN
                 coVerify(exactly = 1) { tvShowDao.getReviewsByTvShowId(tvShowId, language) }
@@ -378,10 +378,10 @@ class TvShowLocalDataSourceImpTest {
         fun `addSeason should add season when addSeason in SeasonDao called successfully`() =
             runTest {
                 //Given
-                tvShowLocalDataSourceImp.addTvShowSeason(Companion.sampleSeason)
+                tvShowLocalDataSourceImpl.addTvShowSeason(Companion.sampleSeason)
 
                 //When&Then
-                coVerify(exactly = 1) { tvShowLocalDataSourceImp.addTvShowSeason(Companion.sampleSeason) }
+                coVerify(exactly = 1) { tvShowLocalDataSourceImpl.addTvShowSeason(Companion.sampleSeason) }
             }
 
         @Test
@@ -398,7 +398,7 @@ class TvShowLocalDataSourceImpTest {
                 } returns Companion.sampleSeason
 
                 //When
-                val result = tvShowLocalDataSourceImp.getSeasonByTvShowIdAndSeasonNumber(
+                val result = tvShowLocalDataSourceImpl.getSeasonByTvShowIdAndSeasonNumber(
                     tvShowId,
                     seasonNumber
                 )
@@ -419,7 +419,7 @@ class TvShowLocalDataSourceImpTest {
             } returns sampleSeason
 
             // When
-            tvShowLocalDataSourceImp.getSeasonByTvShowIdAndSeasonNumber(tvShowId, seasonNumber)
+            tvShowLocalDataSourceImpl.getSeasonByTvShowIdAndSeasonNumber(tvShowId, seasonNumber)
 
             // Then
             coVerify(exactly = 1) {
@@ -444,7 +444,7 @@ class TvShowLocalDataSourceImpTest {
 
             //When
             val result =
-                tvShowLocalDataSourceImp.getSeasonByTvShowIdAndSeasonNumber(tvShowId, seasonNumber)
+                tvShowLocalDataSourceImpl.getSeasonByTvShowIdAndSeasonNumber(tvShowId, seasonNumber)
 
             //Then
             assert(result == null)
@@ -464,7 +464,7 @@ class TvShowLocalDataSourceImpTest {
                 } returns null
 
                 // When
-                tvShowLocalDataSourceImp.getSeasonByTvShowIdAndSeasonNumber(tvShowId, seasonNumber)
+                tvShowLocalDataSourceImpl.getSeasonByTvShowIdAndSeasonNumber(tvShowId, seasonNumber)
 
                 // Then
                 coVerify(exactly = 1) {
@@ -482,7 +482,7 @@ class TvShowLocalDataSourceImpTest {
         fun `addSimilarTvShows should add tv show when addSimilarTvShows in tvShowSimilarDao is called`() =
             runTest {
                 //Given
-                tvShowLocalDataSourceImp.addSimilarTvShows(tvShowSimilarEntity)
+                tvShowLocalDataSourceImpl.addSimilarTvShows(tvShowSimilarEntity)
 
                 //When&Then
                 coVerify(exactly = 1) { tvShowDao.addSimilarTvShows(tvShowSimilarEntity) }
@@ -502,7 +502,7 @@ class TvShowLocalDataSourceImpTest {
                 } returns tvShowSimilarEntity
 
                 //When
-                val result = tvShowLocalDataSourceImp.getSimilarTvShows(
+                val result = tvShowLocalDataSourceImpl.getSimilarTvShows(
                     tvShowId, page,
                     language
                 )
@@ -523,7 +523,7 @@ class TvShowLocalDataSourceImpTest {
             } returns tvShowSimilarEntity
 
             // When
-            tvShowLocalDataSourceImp.getSimilarTvShows(
+            tvShowLocalDataSourceImpl.getSimilarTvShows(
                 tvShowId, page,
                 language
             )
@@ -550,7 +550,7 @@ class TvShowLocalDataSourceImpTest {
             } returns emptyList()
 
             //When
-            val result = tvShowLocalDataSourceImp.getSimilarTvShows(
+            val result = tvShowLocalDataSourceImpl.getSimilarTvShows(
                 tvShowId, page,
                 language
             )
@@ -572,7 +572,7 @@ class TvShowLocalDataSourceImpTest {
             } returns emptyList()
 
             // When
-            tvShowLocalDataSourceImp.getSimilarTvShows(
+            tvShowLocalDataSourceImpl.getSimilarTvShows(
                 tvShowId, page,
                 language
             )

--- a/datasource/local/user/src/main/java/com/paris_2/dataSource/local/user/SettingLocalDataSourceImpl.kt
+++ b/datasource/local/user/src/main/java/com/paris_2/dataSource/local/user/SettingLocalDataSourceImpl.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
-class SettingLocalDataSourceImp @Inject constructor(
+class SettingLocalDataSourceImpl @Inject constructor(
     @ApplicationContext private val context: Context,
 ) : SettingLocalDataSource {
 

--- a/datasource/local/user/src/test/java/com/paris_2/dataSource/local/user/SettingLocalDataSourceImplTest.kt
+++ b/datasource/local/user/src/test/java/com/paris_2/dataSource/local/user/SettingLocalDataSourceImplTest.kt
@@ -13,11 +13,11 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
-class SettingLocalDataSourceImpTest {
+class SettingLocalDataSourceImplTest {
     private lateinit var context: Context
     private lateinit var sharedPreferences: SharedPreferences
     private lateinit var editor: SharedPreferences.Editor
-    private lateinit var dataSource: SettingLocalDataSourceImp
+    private lateinit var dataSource: SettingLocalDataSourceImpl
 
     @BeforeEach
     fun setUp() {
@@ -38,7 +38,7 @@ class SettingLocalDataSourceImpTest {
         every { sharedPreferences.getString("language_code", any()) } returns "en"
         every { sharedPreferences.getBoolean("onboarding_completed", any()) } returns false
 
-        dataSource = SettingLocalDataSourceImp(context)
+        dataSource = SettingLocalDataSourceImpl(context)
     }
 
     @Test
@@ -55,7 +55,7 @@ class SettingLocalDataSourceImpTest {
     fun `getLanguage should emit initial value from SharedPreferences`() = runTest {
         every { sharedPreferences.getString("language_code", any()) } returns "ar"
 
-        val newDataSource = SettingLocalDataSourceImp(context)
+        val newDataSource = SettingLocalDataSourceImpl(context)
 
         assertEquals("ar", newDataSource.getLanguage().first())
     }

--- a/datasource/remote/lists/src/main/java/com/datasource/remote/lists/ListsRemoteDataSourceImpl.kt
+++ b/datasource/remote/lists/src/main/java/com/datasource/remote/lists/ListsRemoteDataSourceImpl.kt
@@ -9,7 +9,7 @@ import com.repository.lists.model.dto.ResponseDto
 import jakarta.inject.Inject
 import retrofit2.HttpException
 
-class ListsRemoteDataSourceImp @Inject constructor(
+class ListsRemoteDataSourceImpl @Inject constructor(
     private val listApiService: ListApiService
 ) : ListsRemoteDataSource {
     override suspend fun getLists(page: Int, accountId: Int): ListsDto = safeApiCall {

--- a/datasource/remote/lists/src/test/java/com/datasource/remote/lists/ListsRemoteDataSourceImplTest.kt
+++ b/datasource/remote/lists/src/test/java/com/datasource/remote/lists/ListsRemoteDataSourceImplTest.kt
@@ -18,17 +18,17 @@ import retrofit2.HttpException
 import java.io.IOException
 import kotlin.test.assertFailsWith
 
-class ListsRemoteDataSourceImpTest {
+class ListsRemoteDataSourceImplTest {
 
     @MockK
     private lateinit var listApiService: ListApiService
 
-    private lateinit var listsRemoteDataSource: ListsRemoteDataSourceImp
+    private lateinit var listsRemoteDataSource: ListsRemoteDataSourceImpl
 
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
-        listsRemoteDataSource = ListsRemoteDataSourceImp(listApiService)
+        listsRemoteDataSource = ListsRemoteDataSourceImpl(listApiService)
     }
 
     @Test

--- a/repository/lists/src/main/java/com/repository/lists/ListsRepositoryImpl.kt
+++ b/repository/lists/src/main/java/com/repository/lists/ListsRepositoryImpl.kt
@@ -10,7 +10,7 @@ import com.repository.lists.dataSource.remote.ListsRemoteDataSource
 import com.repository.lists.exeptions.NetworkException
 import com.repository.lists.mapper.toDomain
 
-class ListsRepositoryImp(
+class ListsRepositoryImpl(
     private val listRemoteDataSource: ListsRemoteDataSource,
     private val remoteDataSource: UserRemoteDataSource,
     ) : ListsRepository {

--- a/repository/lists/src/test/java/com/repository/lists/ListsRepositoryImplTest.kt
+++ b/repository/lists/src/test/java/com/repository/lists/ListsRepositoryImplTest.kt
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
-class ListsRepositoryImpTest {
+class ListsRepositoryImplTest {
 
     @MockK
     private lateinit var listsRemoteDataSource: ListsRemoteDataSource
@@ -30,12 +30,12 @@ class ListsRepositoryImpTest {
     @MockK
     private lateinit var userRemoteDataSource: UserRemoteDataSource
 
-    private lateinit var listsRepositoryImp: ListsRepositoryImp
+    private lateinit var listsRepositoryImpl: ListsRepositoryImpl
 
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
-        listsRepositoryImp = ListsRepositoryImp(listsRemoteDataSource, userRemoteDataSource)
+        listsRepositoryImpl = ListsRepositoryImpl(listsRemoteDataSource, userRemoteDataSource)
     }
 
     @Test
@@ -63,7 +63,7 @@ class ListsRepositoryImpTest {
         coEvery { userRemoteDataSource.getAccountDetails() } returns accountDto
         coEvery { listsRemoteDataSource.getLists(page, accountId) } returns listsDto
 
-        val result = listsRepositoryImp.getLists(page)
+        val result = listsRepositoryImpl.getLists(page)
 
         assertThat(result).hasSize(1)
         assertThat(result[0].id).isEqualTo(1)
@@ -85,7 +85,7 @@ class ListsRepositoryImpTest {
         coEvery { listsRemoteDataSource.getLists(page, accountId) } throws NetworkException.ServerException("Server error")
 
         val exception = assertThrows<ListsNetworkException> {
-            listsRepositoryImp.getLists(page)
+            listsRepositoryImpl.getLists(page)
         }
         assertThat(exception.message).isEqualTo("Server error")
     }
@@ -110,7 +110,7 @@ class ListsRepositoryImpTest {
         )
         coEvery { listsRemoteDataSource.getListDetails(page, listId) } returns listDetailsDto
 
-        val result = listsRepositoryImp.getListDetails(page, listId)
+        val result = listsRepositoryImpl.getListDetails(page, listId)
 
         assertThat(result.id).isEqualTo(123)
         assertThat(result.name).isEqualTo("My List Details")
@@ -136,7 +136,7 @@ class ListsRepositoryImpTest {
         )
         coEvery { listsRemoteDataSource.deleteList(listId) } returns responseDto
 
-        val result = listsRepositoryImp.deleteList(listId)
+        val result = listsRepositoryImpl.deleteList(listId)
 
         assertThat(result).isEqualTo(
             Response(
@@ -157,7 +157,7 @@ class ListsRepositoryImpTest {
         )
         coEvery { listsRemoteDataSource.createList(listName) } returns responseDto
 
-        val result = listsRepositoryImp.createList(listName)
+        val result = listsRepositoryImpl.createList(listName)
 
         assertThat(result).isEqualTo(
             Response(
@@ -179,7 +179,7 @@ class ListsRepositoryImpTest {
         )
         coEvery { listsRemoteDataSource.addMovieToList(listId, movieId) } returns responseDto
 
-        val result = listsRepositoryImp.addMovieToList(listId, movieId)
+        val result = listsRepositoryImpl.addMovieToList(listId, movieId)
 
         assertThat(result).isEqualTo(
             Response(
@@ -201,7 +201,7 @@ class ListsRepositoryImpTest {
         )
         coEvery { listsRemoteDataSource.removeMovieFromList(listId, movieId) } returns responseDto
 
-        val result = listsRepositoryImp.removeMovieFromList(listId, movieId)
+        val result = listsRepositoryImpl.removeMovieFromList(listId, movieId)
 
 
         assertThat(result).isEqualTo(
@@ -228,7 +228,7 @@ class ListsRepositoryImpTest {
         coEvery { listsRemoteDataSource.getLists(page, accountId) } throws NetworkException.UnknownException(errorMessage)
 
         val exception = assertThrows<ListsNetworkException> {
-            listsRepositoryImp.getLists(page)
+            listsRepositoryImpl.getLists(page)
         }
         
         assertThat(exception.message).isEqualTo(errorMessage)
@@ -249,7 +249,7 @@ class ListsRepositoryImpTest {
         coEvery { listsRemoteDataSource.getLists(page, accountId) } throws Exception(errorMessage)
 
         val exception = assertThrows<ListsNetworkException> {
-            listsRepositoryImp.getLists(page)
+            listsRepositoryImpl.getLists(page)
         }
         
         assertThat(exception.message).isEqualTo(errorMessage)
@@ -264,7 +264,7 @@ class ListsRepositoryImpTest {
         coEvery { listsRemoteDataSource.getListDetails(page, listId) } throws NetworkException.UnknownException(errorMessage)
 
         val exception = assertThrows<ListsNetworkException> {
-            listsRepositoryImp.getListDetails(page, listId)
+            listsRepositoryImpl.getListDetails(page, listId)
         }
         
         assertThat(exception.message).isEqualTo(errorMessage)
@@ -279,7 +279,7 @@ class ListsRepositoryImpTest {
         coEvery { listsRemoteDataSource.getListDetails(page, listId) } throws Exception(errorMessage)
 
         val exception = assertThrows<ListsNetworkException> {
-            listsRepositoryImp.getListDetails(page, listId)
+            listsRepositoryImpl.getListDetails(page, listId)
         }
         
         assertThat(exception.message).isEqualTo(errorMessage)
@@ -293,7 +293,7 @@ class ListsRepositoryImpTest {
         coEvery { listsRemoteDataSource.deleteList(listId) } throws NetworkException.UnknownException(errorMessage)
 
         val exception = assertThrows<ListsNetworkException> {
-            listsRepositoryImp.deleteList(listId)
+            listsRepositoryImpl.deleteList(listId)
         }
         
         assertThat(exception.message).isEqualTo(errorMessage)
@@ -307,7 +307,7 @@ class ListsRepositoryImpTest {
         coEvery { listsRemoteDataSource.deleteList(listId) } throws Exception(errorMessage)
 
         val exception = assertThrows<ListsNetworkException> {
-            listsRepositoryImp.deleteList(listId)
+            listsRepositoryImpl.deleteList(listId)
         }
         
         assertThat(exception.message).isEqualTo(errorMessage)
@@ -321,7 +321,7 @@ class ListsRepositoryImpTest {
         coEvery { listsRemoteDataSource.createList(listName) } throws NetworkException.UnknownException(errorMessage)
 
         val exception = assertThrows<ListsNetworkException> {
-            listsRepositoryImp.createList(listName)
+            listsRepositoryImpl.createList(listName)
         }
         
         assertThat(exception.message).isEqualTo(errorMessage)
@@ -335,7 +335,7 @@ class ListsRepositoryImpTest {
         coEvery { listsRemoteDataSource.createList(listName) } throws Exception(errorMessage)
 
         val exception = assertThrows<ListsNetworkException> {
-            listsRepositoryImp.createList(listName)
+            listsRepositoryImpl.createList(listName)
         }
         
         assertThat(exception.message).isEqualTo(errorMessage)
@@ -350,7 +350,7 @@ class ListsRepositoryImpTest {
         coEvery { listsRemoteDataSource.addMovieToList(listId, movieId) } throws NetworkException.UnknownException(errorMessage)
 
         val exception = assertThrows<ListsNetworkException> {
-            listsRepositoryImp.addMovieToList(listId, movieId)
+            listsRepositoryImpl.addMovieToList(listId, movieId)
         }
         
         assertThat(exception.message).isEqualTo(errorMessage)
@@ -365,7 +365,7 @@ class ListsRepositoryImpTest {
         coEvery { listsRemoteDataSource.addMovieToList(listId, movieId) } throws Exception(errorMessage)
 
         val exception = assertThrows<ListsNetworkException> {
-            listsRepositoryImp.addMovieToList(listId, movieId)
+            listsRepositoryImpl.addMovieToList(listId, movieId)
         }
         
         assertThat(exception.message).isEqualTo(errorMessage)
@@ -380,7 +380,7 @@ class ListsRepositoryImpTest {
         coEvery { listsRemoteDataSource.removeMovieFromList(listId, movieId) } throws NetworkException.UnknownException(errorMessage)
 
         val exception = assertThrows<ListsNetworkException> {
-            listsRepositoryImp.removeMovieFromList(listId, movieId)
+            listsRepositoryImpl.removeMovieFromList(listId, movieId)
         }
         
         assertThat(exception.message).isEqualTo(errorMessage)
@@ -395,7 +395,7 @@ class ListsRepositoryImpTest {
         coEvery { listsRemoteDataSource.removeMovieFromList(listId, movieId) } throws Exception(errorMessage)
 
         val exception = assertThrows<ListsNetworkException> {
-            listsRepositoryImp.removeMovieFromList(listId, movieId)
+            listsRepositoryImpl.removeMovieFromList(listId, movieId)
         }
         
         assertThat(exception.message).isEqualTo(errorMessage)

--- a/repository/user/src/main/java/com/paris_2/repository/user/repository/SettingRepositoryImpl.kt
+++ b/repository/user/src/main/java/com/paris_2/repository/user/repository/SettingRepositoryImpl.kt
@@ -5,7 +5,7 @@ import com.paris_2.repository.user.dataSource.local.SettingLocalDataSource
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
-class SettingRepositoryImp(
+class SettingRepositoryImpl(
     private val languageLocalDataSource: SettingLocalDataSource,
 ) : SettingRepository {
     override fun getLanguage(): Flow<String> {

--- a/repository/user/src/test/java/com/paris_2/repository/user/repository/SettingRepositoryImplTest.kt
+++ b/repository/user/src/test/java/com/paris_2/repository/user/repository/SettingRepositoryImplTest.kt
@@ -11,15 +11,15 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 
-class SettingRepositoryImpTest {
+class SettingRepositoryImplTest {
 
     private lateinit var localDataSource: SettingLocalDataSource
-    private lateinit var repository: SettingRepositoryImp
+    private lateinit var repository: SettingRepositoryImpl
 
     @BeforeEach
     fun setUp() {
         localDataSource = mockk(relaxed = true)
-        repository = SettingRepositoryImp(localDataSource)
+        repository = SettingRepositoryImpl(localDataSource)
     }
 
     @Test


### PR DESCRIPTION
Adjusted class names and imports for consistency by changing occurrences from "imp" to "impl".