### PR TITLE
Refactor signing configuration and update dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,33 +18,11 @@ android {
 
     signingConfigs {
         create("release") {
-            val localProps = Properties().apply {
-                val localFile = rootProject.file("local.properties")
-                if (localFile.exists()) {
-                    load(localFile.inputStream())
-                }
-            }
-
-            val keystorePath = System.getenv("KEYSTORE_PATH")
-                ?: localProps.getProperty("KEYSTORE_PATH")
-                ?: throw GradleException("KEYSTORE_PATH is not set.")
-
-            val keystorePassword = System.getenv("KEYSTORE_PASSWORD")
-                ?: localProps.getProperty("KEYSTORE_PASSWORD")
-                ?: throw GradleException("KEYSTORE_PASSWORD is not set.")
-
-            val keyAliasValue = System.getenv("KEY_ALIAS")
-                ?: localProps.getProperty("KEY_ALIAS")
-                ?: throw GradleException("KEY_ALIAS is not set.")
-
-            val keyPasswordValue = System.getenv("KEY_PASSWORD")
-                ?: localProps.getProperty("KEY_PASSWORD")
-                ?: throw GradleException("KEY_PASSWORD is not set.")
-
-            storeFile = file(keystorePath)
-            storePassword = keystorePassword
-            keyAlias = keyAliasValue
-            keyPassword = keyPasswordValue
+            val signingConfig = project.getSigningConfig()
+            storeFile = file(signingConfig.keystorePath)
+            storePassword = signingConfig.keystorePassword
+            keyAlias = signingConfig.keyAlias
+            keyPassword = signingConfig.keyPassword
         }
     }
 

--- a/app/release-info.txt
+++ b/app/release-info.txt
@@ -1,2 +1,6 @@
-versionName=0.8.10
-- add guess game components
+versionName=0.8.11
+- refactor signing config and update dependencies
+- Move signing config to separate SigningExtensions.kt file
+- Update Firebase Crashlytics version to3.0.6
+- Add firebase-perf dependency with version1.4.2
+- Remove duplicate Firebase plugin declarations

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,8 +4,8 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.android.library) apply false
-    id("com.google.firebase.firebase-perf") version "1.4.2" apply false
-    id("com.google.firebase.crashlytics") version "3.0.4" apply false
+    alias(libs.plugins.firebase.perf) apply false
+    alias(libs.plugins.firebase.crashlytics) apply false
     alias(libs.plugins.jetbrains.kotlin.jvm) apply false
     alias(libs.plugins.google.firebase.appdistribution) apply false
     alias(libs.plugins.google.gms.google.services) apply false

--- a/buildSrc/src/main/kotlin/SigningExtensions.kt
+++ b/buildSrc/src/main/kotlin/SigningExtensions.kt
@@ -1,0 +1,38 @@
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import java.io.FileInputStream
+import java.util.Properties
+
+data class SigningConfig(
+    val keystorePath: String,
+    val keystorePassword: String,
+    val keyAlias: String,
+    val keyPassword: String
+)
+
+fun Project.getSigningConfig(): SigningConfig {
+    val localProps = Properties().apply {
+        val localFile = rootProject.file("local.properties")
+        if (localFile.exists()) {
+            load(FileInputStream(localFile))
+        }
+    }
+
+    val keystorePath = System.getenv("KEYSTORE_PATH")
+        ?: localProps.getProperty("KEYSTORE_PATH")
+        ?: throw GradleException("KEYSTORE_PATH is not set.")
+
+    val keystorePassword = System.getenv("KEYSTORE_PASSWORD")
+        ?: localProps.getProperty("KEYSTORE_PASSWORD")
+        ?: throw GradleException("KEYSTORE_PASSWORD is not set.")
+
+    val keyAlias = System.getenv("KEY_ALIAS")
+        ?: localProps.getProperty("KEY_ALIAS")
+        ?: throw GradleException("KEY_ALIAS is not set.")
+
+    val keyPassword = System.getenv("KEY_PASSWORD")
+        ?: localProps.getProperty("KEY_PASSWORD")
+        ?: throw GradleException("KEY_PASSWORD is not set.")
+
+    return SigningConfig(keystorePath, keystorePassword, keyAlias, keyPassword)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ agp = "8.10.1"
 android-youtube-player = "12.1.2"
 datastorePreferences = "1.1.7"
 firebaseBom = "33.16.0"
-firebaseCrashlytics = "3.0.4"
+firebaseCrashlytics = "3.0.6"
 coil = "2.7.0"
 hiltAndroid = "2.57"
 hiltAndroidCompiler = "2.57"
@@ -56,6 +56,7 @@ hiltCommon = "1.2.0"
 datastoreCoreAndroid = "1.1.7"
 foundation = "1.8.3"
 accompanistPagerVersion = "0.36.0"
+firebasePerf = "1.4.2"
 
 [libraries]
 # AndroidX
@@ -171,6 +172,7 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hiltAndroid" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlytics" }
+firebase-perf = { id = "com.google.firebase.firebase-perf", version.ref = "firebasePerf" }
 
 [bundles]
 

--- a/logger/build.gradle.kts
+++ b/logger/build.gradle.kts
@@ -10,9 +10,7 @@ android {
 
     defaultConfig {
         minSdk = Configurations.MIN_SDK
-
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        
     }
 
     buildTypes {
@@ -26,6 +24,9 @@ android {
     }
     kotlinOptions {
         jvmTarget = Configurations.JVM_TARGET
+    }
+    buildFeatures {
+        buildConfig = true
     }
 }
 

--- a/logger/src/main/java/com/parise_2/firebase/firebase/FireBaseCrashlyticsLogger.kt
+++ b/logger/src/main/java/com/parise_2/firebase/firebase/FireBaseCrashlyticsLogger.kt
@@ -2,9 +2,12 @@ package com.parise_2.firebase.firebase
 
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.parise_2.firebase.repo.Logger
+import com.parise_2.logger.BuildConfig
 
 class FireBaseCrashlyticsLogger : Logger {
     override fun logException(exception: Exception) {
-        FirebaseCrashlytics.getInstance().recordException(exception)
+        if (!BuildConfig.DEBUG) {
+            FirebaseCrashlytics.getInstance().recordException(exception)
+        }
     }
 }


### PR DESCRIPTION
- Moved signing configuration to a new `SigningExtensions.kt` file.
- Updated Firebase Crashlytics to version 3.0.6.
- Added `firebase-perf` dependency (version 1.4.2).
- Removed duplicate Firebase plugin declarations.
- Enabled `buildConfig` for the logger module to make crashlytics work only on the release.