### PR TITLE
Add Keep annotation to QuestionType enum

### DIFF
--- a/app/release-info.txt
+++ b/app/release-info.txt
@@ -1,2 +1,2 @@
-versionName=1.0.4
-- Refactor: Simplify profile feature navigation
+versionName=1.0.5
+- fix navigation of guess game question

--- a/feature/guessGame/guessGameUi/src/main/java/com/feature/guessGame/guessGameUi/navigation/Destinations.kt
+++ b/feature/guessGame/guessGameUi/src/main/java/com/feature/guessGame/guessGameUi/navigation/Destinations.kt
@@ -55,6 +55,7 @@ fun String.fromJsonToDestination(): Destination =
     Json.decodeFromString(this)
 
 @Serializable
+@androidx.annotation.Keep
 enum class QuestionType {
     RELEASE_YEAR,
     GENRE,

--- a/feature/guessGame/guessGameUi/src/main/java/com/feature/guessGame/guessGameUi/navigation/Destinations.kt
+++ b/feature/guessGame/guessGameUi/src/main/java/com/feature/guessGame/guessGameUi/navigation/Destinations.kt
@@ -1,5 +1,6 @@
 package com.feature.guessGame.guessGameUi.navigation
 
+import androidx.annotation.Keep
 import com.feature.guessGame.guessGameUi.screen.guessGameScreen.mapper.UiGameLevel
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
@@ -55,7 +56,7 @@ fun String.fromJsonToDestination(): Destination =
     Json.decodeFromString(this)
 
 @Serializable
-@androidx.annotation.Keep
+@Keep
 enum class QuestionType {
     RELEASE_YEAR,
     GENRE,


### PR DESCRIPTION
The `QuestionType` enum in the `guessGameUi` module is now annotated with `@androidx.annotation.Keep`. This ensures that the enum is not removed or renamed during Proguard/R8 optimization, which is important for proper serialization/deserialization with Json.