### PR TITLE
fix bug: crash on start game

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -52,3 +52,5 @@
 -dontwarn com.paris_2.aflami.designsystem.theme.AflamiThemeKt
 -dontwarn com.paris_2.aflami.designsystem.theme.Theme
 -dontwarn org.slf4j.impl.StaticLoggerBinder
+-keep class com.feature.guessGame.guessGameUi.navigation.QuestionType { *; }
+-keep class com.feature.guessGame.guessGameUi.screen.guessGameScreen.mapper.UiGameLevel { *; }

--- a/app/release-info.txt
+++ b/app/release-info.txt
@@ -1,2 +1,2 @@
-versionName=1.0.7
-- improve test coverage in repositories
+versionName=1.0.8
+- fix bug: crash on start game

--- a/feature/guessGame/guessGameUi/src/main/java/com/feature/guessGame/guessGameUi/navigation/Destinations.kt
+++ b/feature/guessGame/guessGameUi/src/main/java/com/feature/guessGame/guessGameUi/navigation/Destinations.kt
@@ -1,6 +1,5 @@
 package com.feature.guessGame.guessGameUi.navigation
 
-import androidx.annotation.Keep
 import com.feature.guessGame.guessGameUi.screen.guessGameScreen.mapper.UiGameLevel
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.Serializable
@@ -56,7 +55,6 @@ fun String.fromJsonToDestination(): Destination =
     Json.decodeFromString(this)
 
 @Serializable
-@Keep
 enum class QuestionType {
     RELEASE_YEAR,
     GENRE,

--- a/feature/guessGame/guessGameUi/src/main/java/com/feature/guessGame/guessGameUi/screen/guessGameScreen/mapper/UiGameLevel.kt
+++ b/feature/guessGame/guessGameUi/src/main/java/com/feature/guessGame/guessGameUi/screen/guessGameScreen/mapper/UiGameLevel.kt
@@ -1,7 +1,9 @@
 package com.feature.guessGame.guessGameUi.screen.guessGameScreen.mapper
 
 import com.feature.guessGame.guessGameUi.R
+import kotlinx.serialization.Serializable
 
+@Serializable
 enum class UiGameLevel {
     EASY, MEDIUM, HARD
 }


### PR DESCRIPTION
Added the `@Serializable` annotation to the `UiGameLevel` and `QuestionType` enums in the guess game feature. This allows these enums to be serialized and deserialized, which is necessary for passing them as navigation arguments.

The `@Keep` annotation was removed from `QuestionType` as it is no longer needed with the addition of `@Serializable` and corresponding Proguard rules.

Updated Proguard rules to keep `UiGameLevel` and `QuestionType` classes during minification.