### PR TITLE
Fix: the critical issues in features 

### DIFF
--- a/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/comon/components/MovieTopComponent.kt
+++ b/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/comon/components/MovieTopComponent.kt
@@ -99,15 +99,20 @@ fun MovieTopComponentDetails(
                 trailingIcons = listOf(
                     iconItemWithDefaults(
                         icon = ImageVector.vectorResource(R.drawable.ic_star),
-                        onClick = {
-                            movieDetailsScreenInteractionListener.onRateClick()
-                        }
+                        onClick = if (state.movieDetailsUiState.movie.isRated.not())
+                            movieDetailsScreenInteractionListener::onRateClick
+                        else null,
+                        tint = if (state.movieDetailsUiState.movie.isRated) Theme.colors.status.yellowAccent
+                        else Theme.colors.text.title
                     ),
                     iconItemWithDefaults(
                         icon = ImageVector.vectorResource(R.drawable.ic_heart_add),
-                        onClick = {
-                            movieDetailsScreenInteractionListener.onAddToListClick()
-                        }
+                        onClick = if (state.movieDetailsUiState.movie.isAddedToLists.not())
+                            movieDetailsScreenInteractionListener::onAddToListClick
+                        else null,
+                        tint = if (state.movieDetailsUiState.movie.isAddedToLists) Theme.colors.status.yellowAccent
+                        else Theme.colors.text.title
+
                     )
                 ),
                 modifier = Modifier
@@ -126,6 +131,7 @@ fun MovieTopComponent(
     sharedTransitionScope: SharedTransitionScope,
     animatedVisibilityScope: AnimatedVisibilityScope,
     title: String,
+    state: MovieDetailsScreenState,
     modifier: Modifier = Modifier,
 ) {
     val activity = LocalActivity.current
@@ -153,15 +159,20 @@ fun MovieTopComponent(
             trailingIcons = listOf(
                 iconItemWithDefaults(
                     icon = ImageVector.vectorResource(R.drawable.ic_star),
-                    onClick = {
-                        movieDetailsScreenInteractionListener.onRateClick()
-                    }
+                    onClick = if (state.movieDetailsUiState.movie.isRated.not())
+                        movieDetailsScreenInteractionListener::onRateClick
+                    else null,
+                    tint = if (state.movieDetailsUiState.movie.isRated) Theme.colors.status.yellowAccent
+                    else Theme.colors.text.title
                 ),
                 iconItemWithDefaults(
                     icon = ImageVector.vectorResource(R.drawable.ic_heart_add),
-                    onClick = {
-                        movieDetailsScreenInteractionListener.onAddToListClick()
-                    }
+                    onClick = if (state.movieDetailsUiState.movie.isAddedToLists.not())
+                        movieDetailsScreenInteractionListener::onAddToListClick
+                    else null,
+                    tint = if (state.movieDetailsUiState.movie.isAddedToLists) Theme.colors.status.yellowAccent
+                    else Theme.colors.text.title
+
                 )
             ),
         )

--- a/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/comon/components/TvTopComponent.kt
+++ b/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/comon/components/TvTopComponent.kt
@@ -90,9 +90,11 @@ fun TopComponentDetails(
                 trailingIcons = listOf(
                     iconItemWithDefaults(
                         icon = ImageVector.vectorResource(R.drawable.ic_star),
-                        onClick = {
-                            tvShowScreenInteractionListener.onRateClick()
-                        }
+                        onClick = if (state.tvShowDetailsUiState.tvShowUi.isRated.not())
+                            tvShowScreenInteractionListener::onRateClick
+                        else null,
+                        tint = if (state.tvShowDetailsUiState.tvShowUi.isRated) Theme.colors.status.yellowAccent
+                        else Theme.colors.text.title
                     ),
                 ),
                 modifier = Modifier
@@ -111,6 +113,7 @@ fun TvTopComponent(
     sharedTransitionScope: SharedTransitionScope,
     animatedVisibilityScope: AnimatedVisibilityScope,
     title: String,
+    state : TvShowDetailsScreenState,
     modifier: Modifier = Modifier,
 ) {
     val activity = LocalActivity.current
@@ -138,9 +141,11 @@ fun TvTopComponent(
             trailingIcons = listOf(
                 iconItemWithDefaults(
                     icon = ImageVector.vectorResource(R.drawable.ic_star),
-                    onClick = {
-                        tvShowScreenInteractionListener.onRateClick()
-                    }
+                    onClick = if (state.tvShowDetailsUiState.tvShowUi.isRated.not())
+                        tvShowScreenInteractionListener::onRateClick
+                    else null,
+                    tint = if (state.tvShowDetailsUiState.tvShowUi.isRated) Theme.colors.status.yellowAccent
+                    else Theme.colors.text.title
                 ),
             ),
         )

--- a/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/comon/components/TvTopComponent.kt
+++ b/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/comon/components/TvTopComponent.kt
@@ -68,7 +68,7 @@ fun TopComponentDetails(
             val tvShowSite = state.tvShowDetailsUiState.tvShowVideoUi.site
             val tvShowKey = state.tvShowDetailsUiState.tvShowVideoUi.key
             DetailsImage(
-                imageUris = listOf(state.tvShowDetailsUiState.tvShowUi.posterUrl) + state.tvShowDetailsUiState.gallery,
+                imageUris = state.tvShowDetailsUiState.gallery,
                 rating = state.tvShowDetailsUiState.tvShowUi.rating,
                 hasVideo = !(tvShowSite.isEmpty() || tvShowKey.isEmpty()),
                 onPlayClick = {

--- a/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/movie/details/MovieDetailsScreen.kt
+++ b/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/movie/details/MovieDetailsScreen.kt
@@ -214,6 +214,7 @@ fun MovieDetailsScreenContent(
                                         animatedVisibilityScope = this@AnimatedContent,
                                         sharedTransitionScope = this@SharedTransitionLayout,
                                         title = state.movieDetailsUiState.movie.title,
+                                        state = state
                                     )
                                 }
 

--- a/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/movie/details/MovieDetailsViewModel.kt
+++ b/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/movie/details/MovieDetailsViewModel.kt
@@ -1,6 +1,5 @@
 package com.feature.mediaDetails.mediaDetailsUi.ui.screen.movie.details
 
-import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute

--- a/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/movie/details/MovieDetailsViewModel.kt
+++ b/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/movie/details/MovieDetailsViewModel.kt
@@ -1,5 +1,6 @@
 package com.feature.mediaDetails.mediaDetailsUi.ui.screen.movie.details
 
+import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
@@ -26,13 +27,16 @@ import com.paris.domain.lists.useCase.AddMovieToListUseCase
 import com.paris.domain.lists.useCase.CreateListUseCase
 import com.paris.domain.lists.useCase.GetListUseCase
 import com.paris.domain.lists.entity.Response
+import com.paris.domain.lists.useCase.GetListDetailsUseCase
 import com.paris_2.aflami.designsystem.components.ButtonState
 import com.paris_2.domain.media.entity.Cast
 import com.paris_2.domain.media.entity.Image
+import com.paris_2.domain.media.entity.MediaType
 import com.paris_2.domain.media.entity.MediaVideo
 import com.paris_2.domain.media.entity.Movie
 import com.paris_2.domain.media.entity.ProductionCompany
 import com.paris_2.domain.media.useCase.AddWatchHistoryUseCase
+import com.paris_2.domain.media.useCase.FilterRatedMediaUseCase
 import com.paris_2.domain.media.useCase.movie.AddRatingToMovieUseCase
 import com.paris_2.domain.media.useCase.movie.GetMovieCastUseCase
 import com.paris_2.domain.media.useCase.movie.GetMovieDetailsUseCase
@@ -41,6 +45,7 @@ import com.paris_2.domain.media.useCase.movie.GetMovieRecommendationsUseCase
 import com.paris_2.domain.media.useCase.movie.GetMovieReviewsUseCase
 import com.paris_2.domain.media.useCase.movie.GetMovieVideoUseCase
 import com.paris_2.domain.media.useCase.movie.GetMoviesProductionCompaniesUseCase
+import com.paris_2.domain.user.usecase.GetAccountIdUseCase
 import com.paris_2.domain.user.usecase.IsLoggedInUseCase
 import com.paris_2.domain.user.usecase.SettingsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -69,6 +74,9 @@ class MovieDetailsViewModel @Inject constructor(
     private val getListsUseCase: GetListUseCase,
     private val createListUseCase: CreateListUseCase,
     private val settingsUseCase: SettingsUseCase,
+    private val getListDetailsUseCase: GetListDetailsUseCase,
+    private val getRatingUseCase: FilterRatedMediaUseCase,
+    private val getAccountIdUseCase: GetAccountIdUseCase,
     navigator: MediaDetailsNavigator,
 ) : MovieDetailsScreenInteractionListener,
     BaseViewModel<MovieDetailsScreenState>(MovieDetailsScreenState(), navigator) {
@@ -221,6 +229,8 @@ class MovieDetailsViewModel @Inject constructor(
     private suspend fun onLoadMovieDetailsSuccess(movie: Movie, mediaId: Int) {
 
         addWatchHistoryUseCase(movie.toMedia())
+        updateMovieIfAddedToList(movieId)
+        updateMovieIfRated(movieId)
         updateState(
             screenState.value.copy(
                 isLoading = false,
@@ -235,6 +245,81 @@ class MovieDetailsViewModel @Inject constructor(
         loadMovieReviews(mediaId)
         loadMovieProductionCompanies(mediaId)
     }
+
+    private fun updateMovieIfAddedToList(mediaId: Int) {
+        tryToExecute(
+            execute = {
+                val isMovieAddedToList: Boolean = getListsUseCase(1)
+                    .any {
+                        getListDetailsUseCase(
+                            1,
+                            it.id.toString()
+                        ).items.any { media ->
+                            media.id == mediaId
+                        }
+                    }
+                isMovieAddedToList
+            },
+            onSuccess = { isMovieAddedToList ->
+                updateState(
+                    screenState.value.copy(
+                        movieDetailsUiState = screenState.value.movieDetailsUiState.copy(
+                            movie = screenState.value.movieDetailsUiState.movie.copy(
+                                isAddedToLists = isMovieAddedToList
+                            )
+                        )
+                    )
+                )
+            },
+            onError = {
+                updateState(
+                    screenState.value.copy(
+                        movieDetailsUiState = screenState.value.movieDetailsUiState.copy(
+                            movie = screenState.value.movieDetailsUiState.movie.copy(
+                                isAddedToLists = false,
+                            )
+                        ),
+                        errorMessage = it
+                    )
+                )
+            },
+        )
+    }
+
+    private fun updateMovieIfRated(mediaId: Int) {
+        tryToExecute(
+            execute = {
+                val accountId = getAccountIdUseCase() ?: -1
+                getRatingUseCase(accountId = accountId, MediaType.Movie).any {
+                    it.id == mediaId
+                }
+            },
+            onSuccess = { isRated ->
+                updateState(
+                    screenState.value.copy(
+                        movieDetailsUiState = screenState.value.movieDetailsUiState.copy(
+                            movie = screenState.value.movieDetailsUiState.movie.copy(
+                                isRated = isRated
+                            )
+                        )
+                    )
+                )
+            },
+            onError = {
+                updateState(
+                    screenState.value.copy(
+                        movieDetailsUiState = screenState.value.movieDetailsUiState.copy(
+                            movie = screenState.value.movieDetailsUiState.movie.copy(
+                                isRated = false,
+                            )
+                        ),
+                        errorMessage = it
+                    )
+                )
+            },
+        )
+    }
+
 
     private fun onLoadMovieDetailsError(error: String) {
         updateState(
@@ -349,7 +434,11 @@ class MovieDetailsViewModel @Inject constructor(
 
     private fun onRateClickSuccess(isLoggedIn: Boolean) {
         if (isLoggedIn) {
-            updateState(screenState.value.copy(showRatingDialog = true))
+            updateState(
+                screenState.value.copy(
+                    showRatingDialog = true,
+                )
+            )
         } else {
             navigate(MediaDetailsDestinations.LoginDialogDestination(R.string.rate))
         }
@@ -395,7 +484,12 @@ class MovieDetailsViewModel @Inject constructor(
         updateState(
             screenState.value.copy(
                 showAddToListDialog = false,
-                selectedListIndex = -1
+                selectedListIndex = -1,
+                movieDetailsUiState = screenState.value.movieDetailsUiState.copy(
+                    movie = screenState.value.movieDetailsUiState.movie.copy(
+                        isAddedToLists = true
+                    )
+                )
             )
         )
         showSuccessSnackBar(R.string.movie_added_to_list_successfully)
@@ -547,7 +641,12 @@ class MovieDetailsViewModel @Inject constructor(
     private fun onRatingSubmittedSuccess(unit: Unit) {
         updateState(
             screenState.value.copy(
-                showRatingDialog = false
+                showRatingDialog = false,
+                movieDetailsUiState = screenState.value.movieDetailsUiState.copy(
+                    movie = screenState.value.movieDetailsUiState.movie.copy(
+                        isRated = true
+                    )
+                )
             )
         )
         showSuccessSnackBar(R.string.rating_submit_successfully)

--- a/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/movie/details/MovieUiState.kt
+++ b/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/movie/details/MovieUiState.kt
@@ -69,6 +69,8 @@ data class MovieUi(
     val country: String = "",
     val description: String = "",
     val productionCompanies: List<ProductionCompanyUi> = emptyList(),
+    val isAddedToLists: Boolean = false,
+    val isRated: Boolean = false
 ): MediaUi
 
 data class ProductionCompanyUi(

--- a/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/tvShow/details/TvShowDetailsScreen.kt
+++ b/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/tvShow/details/TvShowDetailsScreen.kt
@@ -162,6 +162,7 @@ fun TvShowDetailsScreenContent(
                                         animatedVisibilityScope = this@AnimatedContent,
                                         sharedTransitionScope = this@SharedTransitionLayout,
                                         title = state.tvShowDetailsUiState.tvShowUi.title,
+                                        state = state
                                     )
                                 }
 

--- a/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/tvShow/details/TvShowDetailsViewModel.kt
+++ b/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/tvShow/details/TvShowDetailsViewModel.kt
@@ -25,11 +25,13 @@ import com.feature.mediaDetails.mediaDetailsUi.ui.screen.SimilarMediaUI
 import com.feature.mediaDetails.mediaDetailsUi.ui.screen.movie.details.ReviewUi
 import com.paris_2.domain.media.entity.Cast
 import com.paris_2.domain.media.entity.Image
+import com.paris_2.domain.media.entity.MediaType
 import com.paris_2.domain.media.entity.MediaVideo
 import com.paris_2.domain.media.entity.ProductionCompany
 import com.paris_2.domain.media.entity.Season
 import com.paris_2.domain.media.entity.TvShow
 import com.paris_2.domain.media.useCase.AddWatchHistoryUseCase
+import com.paris_2.domain.media.useCase.FilterRatedMediaUseCase
 import com.paris_2.domain.media.useCase.tvShows.AddRatingToTvShowUseCase
 import com.paris_2.domain.media.useCase.tvShows.GetEpisodeVideoUseCase
 import com.paris_2.domain.media.useCase.tvShows.GetSeasonDetailsUseCase
@@ -40,6 +42,7 @@ import com.paris_2.domain.media.useCase.tvShows.GetTvShowRecommendationsUseCase
 import com.paris_2.domain.media.useCase.tvShows.GetTvShowReviewsUseCase
 import com.paris_2.domain.media.useCase.tvShows.GetTvShowVideoUseCase
 import com.paris_2.domain.media.useCase.tvShows.GetTvShowsProductionCompaniesUseCase
+import com.paris_2.domain.user.usecase.GetAccountIdUseCase
 import com.paris_2.domain.user.usecase.IsLoggedInUseCase
 import com.paris_2.domain.user.usecase.SettingsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -66,6 +69,8 @@ class TvShowDetailsViewModel @Inject constructor(
     private val isLoggedInUseCase: IsLoggedInUseCase,
     private val addRatingToTvShowUseCase: AddRatingToTvShowUseCase,
     private val settingsUseCase: SettingsUseCase,
+    private val getRatingUseCase: FilterRatedMediaUseCase,
+    private val getAccountIdUseCase: GetAccountIdUseCase,
     navigator: MediaDetailsNavigator,
 ) : TvShowScreenInteractionListener, BaseViewModel<TvShowDetailsScreenState>(
     TvShowDetailsScreenState(
@@ -175,6 +180,7 @@ class TvShowDetailsViewModel @Inject constructor(
     
     private suspend fun onLoadTvShowDetailsSuccess(tvShow: TvShow, mediaId: Int) {
         addWatchHistoryUseCase(tvShow.toMedia())
+        updateTvShowIfItRated(mediaId)
         updateState(
             screenState.value.copy(
                 tvShowDetailsUiState = screenState.value.tvShowDetailsUiState.copy(
@@ -190,7 +196,41 @@ class TvShowDetailsViewModel @Inject constructor(
         loadTvShowReviews(mediaId)
         loadTvShowsProductionCompanies(mediaId)
     }
-    
+
+    private fun updateTvShowIfItRated(mediaId: Int) {
+        tryToExecute(
+            execute = {
+                val accountId = getAccountIdUseCase() ?: -1
+                getRatingUseCase(accountId = accountId, MediaType.TvShow).any {
+                    it.id == mediaId
+                }
+            },
+            onSuccess = { isRated ->
+                updateState(
+                    screenState.value.copy(
+                        tvShowDetailsUiState = screenState.value.tvShowDetailsUiState.copy(
+                            tvShowUi = screenState.value.tvShowDetailsUiState.tvShowUi.copy(
+                                isRated = isRated
+                            )
+                        )
+                    )
+                )
+            },
+            onError = {
+                updateState(
+                    screenState.value.copy(
+                        tvShowDetailsUiState = screenState.value.tvShowDetailsUiState.copy(
+                            tvShowUi = screenState.value.tvShowDetailsUiState.tvShowUi.copy(
+                                isRated = false
+                            )
+                        ),
+                        errorMessage = it
+                    )
+                )
+            },
+        )
+    }
+
     private fun onLoadTvShowDetailsError(error: String) {
         updateState(
             screenState.value.copy(
@@ -414,7 +454,12 @@ class TvShowDetailsViewModel @Inject constructor(
                 showSnackBar = true,
                 snackBarSuccess = true,
                 snackBarMessage = R.string.rating_submit_successfully,
-                showRatingDialog = false
+                showRatingDialog = false,
+                tvShowDetailsUiState = screenState.value.tvShowDetailsUiState.copy(
+                    tvShowUi = screenState.value.tvShowDetailsUiState.tvShowUi.copy(
+                        isRated = true
+                    )
+                )
             )
         )
         hideSnackBar()

--- a/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/tvShow/details/TvShowUiState.kt
+++ b/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/tvShow/details/TvShowUiState.kt
@@ -49,7 +49,7 @@ data class TvShowDetailsUiState(
     val selectedRating: Float = 0f,
     val episodeVideoUi: EpisodeVideoUi = EpisodeVideoUi(),
     val isYoutubePlayerVisible: Boolean = false,
-    val youtubeVideoKey: String? = null
+    val youtubeVideoKey: String? = null,
 )
 
 data class TvShowVideoUi(
@@ -70,7 +70,8 @@ data class TvShowUi(
     val description: String = "",
     val seasons: List<SeasonUi> = emptyList(),
     val productionCompanies: List<ProductionCompanyUi> = emptyList(),
-) : MediaUi
+    val isRated:Boolean = false,
+    ) : MediaUi
 
 data class SeasonUi(
     val id: Int = 0,

--- a/feature/mediaDetails/mediaDetailsUi/src/test/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/details/MovieDetailsViewModelTest.kt
+++ b/feature/mediaDetails/mediaDetailsUi/src/test/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/details/MovieDetailsViewModelTest.kt
@@ -25,9 +25,12 @@ import com.feature.mediaDetails.mediaDetailsUi.ui.screen.movie.details.ReviewUi
 import com.paris.domain.lists.entity.Response
 import com.paris.domain.lists.useCase.AddMovieToListUseCase
 import com.paris.domain.lists.useCase.CreateListUseCase
+import com.paris.domain.lists.useCase.GetListDetailsUseCase
 import com.paris.domain.lists.useCase.GetListUseCase
 import com.paris_2.domain.media.entity.MediaVideo
 import com.paris_2.domain.media.useCase.AddWatchHistoryUseCase
+import com.paris_2.domain.media.useCase.FilterRatedMediaUseCase
+import com.paris_2.domain.user.usecase.GetAccountIdUseCase
 import com.paris_2.domain.user.usecase.SettingsUseCase
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
@@ -66,6 +69,9 @@ class MovieDetailsViewModelTest {
     private val createListUseCase: CreateListUseCase = mockk()
     private val getSessionIdUseCase: AddMovieToListUseCase = mockk()
     private val settingsUseCase: SettingsUseCase = mockk()
+    private val getListDetailsUseCase: GetListDetailsUseCase = mockk()
+    private val getRatingUseCase: FilterRatedMediaUseCase = mockk()
+    private val getAccountIdUseCase: GetAccountIdUseCase = mockk()
     private lateinit var viewModel: MovieDetailsViewModel
     private val testDispatcher = StandardTestDispatcher()
     private val testMovieId = 42
@@ -152,6 +158,8 @@ class MovieDetailsViewModelTest {
         coEvery { getMovieDetailsUseCase(any()) } returns mockk<Movie>(relaxed = true)
         coEvery { getMovieVideoUseCase(any()) } throws RuntimeException(errorMsg)
         coEvery { getListsUseCase(any()) } returns emptyList()
+        coEvery { getAccountIdUseCase() } throws RuntimeException(errorMsg)
+
         viewModel = makeViewModelWithDefaultStateHandle()
         runCurrent()
         assertEquals(errorMsg, viewModel.screenState.value.errorMessage)
@@ -234,7 +242,7 @@ class MovieDetailsViewModelTest {
         val uiReviews = listOf(mockk<ReviewUi>())
 
         val domainMovie = mockk<Movie>(relaxed = true)
-        val movieUi = mockk<MovieUi>()
+        val movieUi = MovieUi()
 
         coEvery { getMovieDetailsUseCase(testMovieId) } returns domainMovie
         coEvery { getMovieVideoUseCase(testMovieId) } returns mockk<MediaVideo>(relaxed = true)
@@ -410,7 +418,10 @@ class MovieDetailsViewModelTest {
             getListsUseCase,
             createListUseCase,
             settingsUseCase,
-            mediaDetailsNavigator
+            getListDetailsUseCase,
+            getRatingUseCase,
+            getAccountIdUseCase,
+            mediaDetailsNavigator,
         )
     }
 }

--- a/feature/mediaDetails/mediaDetailsUi/src/test/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/details/TvShowDetailsViewModelTest.kt
+++ b/feature/mediaDetails/mediaDetailsUi/src/test/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/details/TvShowDetailsViewModelTest.kt
@@ -13,6 +13,7 @@ import com.paris_2.domain.media.entity.Review
 import com.paris_2.domain.media.entity.Season
 import com.paris_2.domain.media.entity.TvShow
 import com.paris_2.domain.media.useCase.AddWatchHistoryUseCase
+import com.paris_2.domain.media.useCase.FilterRatedMediaUseCase
 import com.paris_2.domain.media.useCase.tvShows.AddRatingToTvShowUseCase
 import com.paris_2.domain.media.useCase.tvShows.GetEpisodeVideoUseCase
 import com.paris_2.domain.media.useCase.tvShows.GetSeasonDetailsUseCase
@@ -23,6 +24,7 @@ import com.paris_2.domain.media.useCase.tvShows.GetTvShowRecommendationsUseCase
 import com.paris_2.domain.media.useCase.tvShows.GetTvShowReviewsUseCase
 import com.paris_2.domain.media.useCase.tvShows.GetTvShowVideoUseCase
 import com.paris_2.domain.media.useCase.tvShows.GetTvShowsProductionCompaniesUseCase
+import com.paris_2.domain.user.usecase.GetAccountIdUseCase
 import com.paris_2.domain.user.usecase.IsLoggedInUseCase
 import com.paris_2.domain.user.usecase.SettingsUseCase
 import io.mockk.clearAllMocks
@@ -61,6 +63,8 @@ class TvShowDetailsViewModelTest {
     private val addWatchHistoryUseCase: AddWatchHistoryUseCase = mockk(relaxed = true)
     private val settingsUseCase: SettingsUseCase = mockk()
     private val addRatingToTvShowUseCase: AddRatingToTvShowUseCase = mockk()
+    private val getRatingUseCase: FilterRatedMediaUseCase= mockk()
+    private val getAccountIdUseCase: GetAccountIdUseCase = mockk()
     private lateinit var viewModel: TvShowDetailsViewModel
     private val testDispatcher = StandardTestDispatcher()
     private val testTvShowId = 88
@@ -162,6 +166,7 @@ class TvShowDetailsViewModelTest {
         val errorMsg = "videoFail"
         coEvery { getTvShowDetailsUseCase(any()) } returns mockk<TvShow>(relaxed = true)
         coEvery { getTvShowVideoUseCase(any()) } throws RuntimeException(errorMsg)
+        coEvery { getAccountIdUseCase() } throws RuntimeException(errorMsg)
         viewModel = makeViewModelWithDefaultStateHandle()
         runCurrent()
         assertEquals(errorMsg, viewModel.screenState.value.errorMessage)
@@ -353,6 +358,8 @@ class TvShowDetailsViewModelTest {
             isLoggedInUseCase,
             addRatingToTvShowUseCase,
             settingsUseCase,
+            getRatingUseCase,
+            getAccountIdUseCase,
             navigator
         )
     }


### PR DESCRIPTION
Fix: the problem of not loading first image in gallery of tvShow details  , Update image URIs in TvTopComponent
Refactor: Update TV show rating status and UI
Refactor: Update movie details UI state ( rating and addToList Icons )


-   Updated `MovieDetailsViewModel` to check if a movie has been added to a list or rated, and reflect this in the UI state.
-   Modified `MovieUiState` to include `isAddedToLists` and `isRated` boolean flags.
-   Adjusted `MovieTopComponent` and `MovieDetailsScreen` to utilize the new UI state flags to conditionally enable/disable and change the tint of the "add to list" and "rate" icons.

- Adds an `isRated` flag to `TvShowUi` to track whether a TV show has been rated by the user.
- Updates `TvShowDetailsViewModel` to fetch and update the `isRated` status of a TV show upon loading its details.
- Modifies the UI in `TvShowDetailsScreen` and `TvTopComponent` to reflect the rated status:
    - The rate button is disabled and its icon color changes if the TV show is already rated.
- Updates the `isRated` flag to `true` when a rating is successfully submitted.

The `DetailsImage` composable in `TvTopComponent` now directly uses the `gallery` from `tvShowDetailsUiState` for its `imageUris` parameter.

Previously, it was prepending `state.tvShowDetailsUiState.tvShowUi.posterUrl` to the `gallery` list. This change simplifies the image source logic.