### PR TITLE
Fix: Default to dark theme and optimize movie list check

### DIFF
--- a/app/release-info.txt
+++ b/app/release-info.txt
@@ -1,2 +1,2 @@
-versionName=1.0.16
-- Refactor Guess Game Crash When User Is A Guest
+versionName=1.0.17
+- refactor updateMovieIfAddedToList logic

--- a/datasource/local/user/src/main/java/com/paris_2/dataSource/local/user/SettingLocalDataSourceImpl.kt
+++ b/datasource/local/user/src/main/java/com/paris_2/dataSource/local/user/SettingLocalDataSourceImpl.kt
@@ -61,10 +61,6 @@ class SettingLocalDataSourceImpl @Inject constructor(
         }.first()
     }
 
-    private fun isSystemInDarkTheme(): Boolean {
-        return (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
-    }
-
     private suspend fun <T> DataStore<Preferences>.setValue(
         key: Preferences.Key<T>,
         value: T,

--- a/datasource/local/user/src/main/java/com/paris_2/dataSource/local/user/SettingLocalDataSourceImpl.kt
+++ b/datasource/local/user/src/main/java/com/paris_2/dataSource/local/user/SettingLocalDataSourceImpl.kt
@@ -47,7 +47,7 @@ class SettingLocalDataSourceImpl @Inject constructor(
 
     override fun getTheme(): Flow<Boolean> {
         return dataStore.data.mapLatest {
-            it[KEY_IS_DARK_THEME] ?: isSystemInDarkTheme()
+            it[KEY_IS_DARK_THEME] ?: true
         }
     }
 

--- a/feature/home/homeUi/src/main/java/com/feature/home/homeUi/screen/topRatingMovies/TopRatingMoviesScreen.kt
+++ b/feature/home/homeUi/src/main/java/com/feature/home/homeUi/screen/topRatingMovies/TopRatingMoviesScreen.kt
@@ -120,7 +120,6 @@ fun TopRatingMoviesScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(top = 12.dp)
         ) {
 
             AppTopBar(

--- a/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/comon/components/castSection/CastItem.kt
+++ b/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/comon/components/castSection/CastItem.kt
@@ -75,7 +75,7 @@ fun CastItem(
             AsyncImage(
                 model = imageUrl,
                 contentDescription = null,
-                contentScale = ContentScale.Fit,
+                contentScale = ContentScale.Crop,
                 modifier = Modifier
                     .matchParentSize(),
                 onLoading = {

--- a/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/comon/components/detailsImage/DetailsImage.kt
+++ b/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/comon/components/detailsImage/DetailsImage.kt
@@ -83,7 +83,7 @@ fun DetailsImage(
                         modifier = Modifier
                             .fillMaxWidth()
                             .align(Alignment.Center),
-                        contentScale = ContentScale.Fit,
+                        contentScale = ContentScale.Crop,
                         contentDescription = "poster",
                         nsfwThreshold = nsfwThreshold,
                         genderThreshold = genderThreshold,

--- a/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/movie/details/MovieDetailsViewModel.kt
+++ b/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/movie/details/MovieDetailsViewModel.kt
@@ -207,6 +207,7 @@ class MovieDetailsViewModel @Inject constructor(
                 }
             )
         )
+        updateMovieIfAddedToList(movieId)
     }
 
     private fun getInformationVideoMovie() {
@@ -228,7 +229,6 @@ class MovieDetailsViewModel @Inject constructor(
     private suspend fun onLoadMovieDetailsSuccess(movie: Movie, mediaId: Int) {
 
         addWatchHistoryUseCase(movie.toMedia())
-        updateMovieIfAddedToList(movieId)
         updateMovieIfRated(movieId)
         updateState(
             screenState.value.copy(
@@ -248,16 +248,12 @@ class MovieDetailsViewModel @Inject constructor(
     private fun updateMovieIfAddedToList(mediaId: Int) {
         tryToExecute(
             execute = {
-                val isMovieAddedToList: Boolean = getListsUseCase(1)
-                    .any {
-                        getListDetailsUseCase(
-                            1,
-                            it.id.toString()
-                        ).items.any { media ->
+                screenState.value.availableLists
+                    .map { listItemUi ->
+                        getListDetailsUseCase(1, listItemUi.id).items.any { media ->
                             media.id == mediaId
                         }
-                    }
-                isMovieAddedToList
+                    }.any { it }
             },
             onSuccess = { isMovieAddedToList ->
                 updateState(

--- a/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/movie/details/MovieDetailsViewModel.kt
+++ b/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/movie/details/MovieDetailsViewModel.kt
@@ -48,6 +48,8 @@ import com.paris_2.domain.user.usecase.GetAccountIdUseCase
 import com.paris_2.domain.user.usecase.IsLoggedInUseCase
 import com.paris_2.domain.user.usecase.SettingsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
@@ -248,12 +250,14 @@ class MovieDetailsViewModel @Inject constructor(
     private fun updateMovieIfAddedToList(mediaId: Int) {
         tryToExecute(
             execute = {
-                screenState.value.availableLists
-                    .map { listItemUi ->
+                val deferredResults = screenState.value.availableLists.map { listItemUi ->
+                    viewModelScope.async {
                         getListDetailsUseCase(1, listItemUi.id).items.any { media ->
                             media.id == mediaId
                         }
-                    }.any { it }
+                    }
+                }
+                deferredResults.awaitAll().any { it }
             },
             onSuccess = { isMovieAddedToList ->
                 updateState(

--- a/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/movie/details/MovieUiState.kt
+++ b/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/movie/details/MovieUiState.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.emptyFlow
 
 data class MovieDetailsScreenState(
     val movieDetailsUiState: MovieDetailsUiState = MovieDetailsUiState(),
-    val isLoading: Boolean = false,
+    val isLoading: Boolean = true,
     val errorMessage: String? = null,
     val isImageLoading: Boolean = false,
     val isDescriptionLoading: Boolean = false,


### PR DESCRIPTION
- Changed the default theme in `SettingLocalDataSourceImpl` to dark theme (`true`) if no theme is set.
- Modified `MovieDetailsScreenState` to set `isLoading` to `true` by default.
- In `MovieDetailsViewModel`, moved `updateMovieIfAddedToList(movieId)` to be called immediately after fetching movie details.
- Optimized `updateMovieIfAddedToList` to check for movie existence directly within the existing `screenState.value.availableLists` instead of re-fetching lists.