### PR TITLE
bug-fix/fix-tv-show-scrolling

### DIFF
--- a/app/release-info.txt
+++ b/app/release-info.txt
@@ -1,2 +1,2 @@
-versionName=1.0.23
-- delete unused files and rename fields
+versionName=1.0.24
+- fix tv show scrolling behaviour

--- a/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/paging/PagingSource.kt
+++ b/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/paging/PagingSource.kt
@@ -12,7 +12,7 @@ class PagingSource<Media: Any>(
         return try {
             val response = mediaUseCase(page)
             LoadResult.Page(
-                data = response as List<Media>,
+                data = response,
                 prevKey = if (page == 1) null else page - 1,
                 nextKey = if (response.isEmpty()) null else page + 1
             )

--- a/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/movie/details/MovieDetailsScreen.kt
+++ b/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/movie/details/MovieDetailsScreen.kt
@@ -40,6 +40,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
@@ -97,6 +99,8 @@ fun MovieDetailsScreenContent(
     val selectedIndex = rememberSaveable { mutableIntStateOf(defaultIndex) }
     val mediaList = state.movieDetailsUiState.recommendations.collectAsLazyPagingItems()
     val scrollState = rememberLazyGridState()
+
+    val screenHeight = with(LocalDensity){ LocalWindowInfo.current.containerSize.height.dp }
 
     LaunchedEffect(state.snackBarSuccess, state.showSnackBar) {
         if (state.showSnackBar && state.snackBarSuccess) {
@@ -429,7 +433,7 @@ fun MovieDetailsScreenContent(
                             Spacer(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .height(LocalConfiguration.current.screenHeightDp.dp / 12)
+                                    .height(screenHeight/11)
                             )
                         }
                     }

--- a/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/tvShow/details/TvShowDetailsScreen.kt
+++ b/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/tvShow/details/TvShowDetailsScreen.kt
@@ -463,7 +463,7 @@ fun TvShowDetailsScreenContent(
                             Spacer(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .height(screenHeight/10)
+                                    .height(screenHeight/11)
                             )
                         }
                     }

--- a/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/tvShow/details/TvShowDetailsScreen.kt
+++ b/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/tvShow/details/TvShowDetailsScreen.kt
@@ -40,7 +40,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -102,6 +103,8 @@ fun TvShowDetailsScreenContent(
         mutableStateOf(List(state.tvShowDetailsUiState.tvShowUi.seasons.size) { false })
     }
     val reviewsList = state.tvShowDetailsUiState.reviews
+
+    val screenHeight = with(LocalDensity){ LocalWindowInfo.current.containerSize.height.dp }
 
     LaunchedEffect(isCollapsed) {
         if (isCollapsed && scrollState.layoutInfo.totalItemsCount > 0) {
@@ -460,7 +463,7 @@ fun TvShowDetailsScreenContent(
                             Spacer(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .height(LocalConfiguration.current.screenHeightDp.dp / 12)
+                                    .height(screenHeight/11)
                             )
                         }
                     }

--- a/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/tvShow/details/TvShowDetailsScreen.kt
+++ b/feature/mediaDetails/mediaDetailsUi/src/main/java/com/feature/mediaDetails/mediaDetailsUi/ui/screen/tvShow/details/TvShowDetailsScreen.kt
@@ -463,7 +463,7 @@ fun TvShowDetailsScreenContent(
                             Spacer(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .height(screenHeight/11)
+                                    .height(screenHeight/10)
                             )
                         }
                     }


### PR DESCRIPTION
Fix tv show scrolling behaviour

 addresses an issue with scrolling in the TV show and movie  details screen.
It also removes an unnecessary cast in the PagingSource.kt file and updates the app version in release-info.txt.