### PR TITLE
Refactor: Update AppSlider for dynamic width and add preview

### DIFF
--- a/app/release-info.txt
+++ b/app/release-info.txt
@@ -1,2 +1,2 @@
-versionName=1.0.35
-- ensured consistent expandedHeight behavior across different screen sizes
+versionName=1.0.36
+- update home slider

--- a/designsystem/src/main/java/com/paris/aflami/designsystem/utils/MultipreviewsAnnotations.kt
+++ b/designsystem/src/main/java/com/paris/aflami/designsystem/utils/MultipreviewsAnnotations.kt
@@ -27,5 +27,11 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
     device = "spec:width=1280dp,height=800dp,dpi=480"
 )
 
+@Preview(
+    name = "Desktop",
+    group = "devices",
+    device = "spec:width=1920dp,height=1080dp,dpi=480"
+)
+
 @PreviewLightDark
 annotation class PreviewMultiDevices

--- a/feature/home/homeUi/src/main/java/com/feature/home/homeUi/screen/home/components/AppSlider.kt
+++ b/feature/home/homeUi/src/main/java/com/feature/home/homeUi/screen/home/components/AppSlider.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.fontscaling.MathUtils.lerp
 import com.feature.home.homeUi.R
@@ -80,8 +81,10 @@ fun AppSlider(
     }
 
     val configuration = LocalConfiguration.current
-    val screenWidth = LocalConfiguration.current.screenWidthDp.dp
-    val screenCenterPx = with(LocalDensity.current) { screenWidth.toPx() } / 2f
+    val screenWidth = LocalWindowInfo.current.containerSize.width
+    val screenWidthDp = with(LocalDensity.current) { screenWidth.dp }
+    val screenCenterPx = with(LocalDensity.current) { screenWidth.dp.toPx() } / 2f
+
 
     Box(
         modifier = modifier,
@@ -92,7 +95,7 @@ fun AppSlider(
             contentPadding = if (configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
                 PaddingValues(horizontal = 80.dp)
             } else
-                PaddingValues(horizontal = 300.dp),
+                PaddingValues(horizontal = screenWidthDp/8),
             modifier = Modifier.fillMaxWidth(),
             beyondViewportPageCount = 2,
         ) { page ->
@@ -181,6 +184,51 @@ fun SliderPreview() {
                 categories = listOf(R.string.category_animation),
                 rating = 9.0f,
                 yearOfRelease = "2022"
+            ),
+            SliderMedia(
+                id = 3,
+                imageUri = "https://image.tmdb.org/t/p/w500/your_sample_image3.jpg",
+                title = "Sample Movie 2",
+                type = SliderMediaTypeUi.Movie,
+                categories = listOf(R.string.category_action),
+                rating = 7.8f,
+                yearOfRelease = "2024"
+            ),
+            SliderMedia(
+                id = 3,
+                imageUri = "https://image.tmdb.org/t/p/w500/your_sample_image3.jpg",
+                title = "Sample Movie 2",
+                type = SliderMediaTypeUi.Movie,
+                categories = listOf(R.string.category_action),
+                rating = 7.8f,
+                yearOfRelease = "2024"
+            ),
+            SliderMedia(
+                id = 3,
+                imageUri = "https://image.tmdb.org/t/p/w500/your_sample_image3.jpg",
+                title = "Sample Movie 2",
+                type = SliderMediaTypeUi.Movie,
+                categories = listOf(R.string.category_action),
+                rating = 7.8f,
+                yearOfRelease = "2024"
+            ),
+            SliderMedia(
+                id = 3,
+                imageUri = "https://image.tmdb.org/t/p/w500/your_sample_image3.jpg",
+                title = "Sample Movie 2",
+                type = SliderMediaTypeUi.Movie,
+                categories = listOf(R.string.category_action),
+                rating = 7.8f,
+                yearOfRelease = "2024"
+            ),
+            SliderMedia(
+                id = 3,
+                imageUri = "https://image.tmdb.org/t/p/w500/your_sample_image3.jpg",
+                title = "Sample Movie 2",
+                type = SliderMediaTypeUi.Movie,
+                categories = listOf(R.string.category_action),
+                rating = 7.8f,
+                yearOfRelease = "2024"
             ),
             SliderMedia(
                 id = 3,

--- a/feature/home/homeUi/src/main/java/com/feature/home/homeUi/screen/home/components/AppSlider.kt
+++ b/feature/home/homeUi/src/main/java/com/feature/home/homeUi/screen/home/components/AppSlider.kt
@@ -93,7 +93,7 @@ fun AppSlider(
         HorizontalPager(
             state = pagerState,
             contentPadding = if (configuration.orientation == Configuration.ORIENTATION_PORTRAIT) {
-                PaddingValues(horizontal = 80.dp)
+                PaddingValues(horizontal = 70.dp)
             } else
                 PaddingValues(horizontal = screenWidthDp/8),
             modifier = Modifier.fillMaxWidth(),

--- a/feature/home/homeUi/src/main/java/com/feature/home/homeUi/screen/home/components/HomeSlider.kt
+++ b/feature/home/homeUi/src/main/java/com/feature/home/homeUi/screen/home/components/HomeSlider.kt
@@ -243,5 +243,31 @@ val loadingList = listOf(
         categories = emptyList(),
         rating = 0f,
         yearOfRelease = "2022",
+    ),
+    SliderMedia(
+        id = 0,
+        imageUri = "",
+        title = "",
+        type = SliderMediaTypeUi.Movie,
+        categories = emptyList(),
+        rating = 0f,
+        yearOfRelease = "2022",
+    ),
+    SliderMedia(
+        id = 0,
+        imageUri = "",
+        title = "",
+        type = SliderMediaTypeUi.Movie,
+        categories = emptyList(),
+        rating = 0f,
+        yearOfRelease = "2022",
+    ),SliderMedia(
+        id = 0,
+        imageUri = "",
+        title = "",
+        type = SliderMediaTypeUi.Movie,
+        categories = emptyList(),
+        rating = 0f,
+        yearOfRelease = "2022",
     )
 )


### PR DESCRIPTION
Refactor: Update AppSlider for dynamic width and add preview

- Modified `AppSlider` to use `LocalWindowInfo.current.containerSize.width` for screen width calculation, making it adaptive to different screen sizes.
- Adjusted horizontal padding in landscape mode to be `screenWidthDp/8`.
- Added more `SliderMedia` items to the preview in `AppSlider`.
- Added more `SliderMedia` items to the preview in `HomeSlider`.
- Introduced a "Desktop" preview configuration in `MultipreviewsAnnotations.kt`.
- Updated release notes.